### PR TITLE
Render Markdown in task cards

### DIFF
--- a/src/views/task-assignment-view.ts
+++ b/src/views/task-assignment-view.ts
@@ -519,13 +519,13 @@ export class TaskAssignmentView extends TaskAssignmentViewBase {
 		const contentEl = cardEl.createDiv('task-assignment-card-content');
 		
 		// Task description
-                const descriptionEl = contentEl.createDiv('task-assignment-card-description');
-                MarkdownRenderer.renderMarkdown(
-                        task.description,
-                        descriptionEl,
-                        task.filePath,
-                        this
-                );
+		const descriptionEl = contentEl.createDiv('task-assignment-card-description');
+		MarkdownRenderer.renderMarkdown(
+				task.description,
+				descriptionEl,
+				task.filePath,
+				this
+		);
 		
 		// Task metadata
 		const metadataEl = contentEl.createDiv('task-assignment-card-metadata');
@@ -592,15 +592,15 @@ export class TaskAssignmentView extends TaskAssignmentViewBase {
 		const contentEl = this.sidePanel.createDiv('task-assignment-side-panel-content');
 		
 		// Task description
-                const descriptionEl = contentEl.createDiv('task-detail-section');
-                descriptionEl.createEl('h3', { text: 'Description' });
-                const descriptionValue = descriptionEl.createDiv('task-detail-value');
-                MarkdownRenderer.renderMarkdown(
-                        this.selectedTask.description,
-                        descriptionValue,
-                        this.selectedTask.filePath,
-                        this
-                );
+        const descriptionEl = contentEl.createDiv('task-detail-section');
+        descriptionEl.createEl('h3', { text: 'Description' });
+        const descriptionValue = descriptionEl.createDiv('task-detail-value');
+        MarkdownRenderer.renderMarkdown(
+			this.selectedTask.description,
+			descriptionValue,
+			this.selectedTask.filePath,
+			this
+		);
 
 		// File location
 		const locationEl = contentEl.createDiv('task-detail-section');

--- a/src/views/task-assignment-view.ts
+++ b/src/views/task-assignment-view.ts
@@ -1,4 +1,4 @@
-import { WorkspaceLeaf, setIcon } from 'obsidian';
+import { WorkspaceLeaf, setIcon, MarkdownRenderer } from 'obsidian';
 import { TaskAssignmentViewBase } from './task-assignment-view-base';
 import { TaskData, ViewLayout, TaskStatus, TaskPriority, DateType, ViewFilters } from '../types';
 import { TaskCacheService } from '../services/task-cache.service';
@@ -519,8 +519,13 @@ export class TaskAssignmentView extends TaskAssignmentViewBase {
 		const contentEl = cardEl.createDiv('task-assignment-card-content');
 		
 		// Task description
-		const descriptionEl = contentEl.createDiv('task-assignment-card-description');
-		descriptionEl.setText(task.description);
+                const descriptionEl = contentEl.createDiv('task-assignment-card-description');
+                MarkdownRenderer.renderMarkdown(
+                        task.description,
+                        descriptionEl,
+                        task.filePath,
+                        this
+                );
 		
 		// Task metadata
 		const metadataEl = contentEl.createDiv('task-assignment-card-metadata');
@@ -587,9 +592,15 @@ export class TaskAssignmentView extends TaskAssignmentViewBase {
 		const contentEl = this.sidePanel.createDiv('task-assignment-side-panel-content');
 		
 		// Task description
-		const descriptionEl = contentEl.createDiv('task-detail-section');
-		descriptionEl.createEl('h3', { text: 'Description' });
-		descriptionEl.createDiv('task-detail-value').setText(this.selectedTask.description);
+                const descriptionEl = contentEl.createDiv('task-detail-section');
+                descriptionEl.createEl('h3', { text: 'Description' });
+                const descriptionValue = descriptionEl.createDiv('task-detail-value');
+                MarkdownRenderer.renderMarkdown(
+                        this.selectedTask.description,
+                        descriptionValue,
+                        this.selectedTask.filePath,
+                        this
+                );
 
 		// File location
 		const locationEl = contentEl.createDiv('task-detail-section');


### PR DESCRIPTION
## Summary
- display markdown content in task cards
- show markdown in the task detail side panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686be7d23d7c83298a8d589cd3e8c0e9