### PR TITLE
Add date icons to task cards

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -100,11 +100,18 @@ export interface DateRange {
 }
 
 export enum DateType {
-	CREATED = 'created',
-	DUE = 'due',
-	COMPLETED = 'completed',
-	SCHEDULED = 'scheduled'
+        CREATED = 'created',
+        DUE = 'due',
+        COMPLETED = 'completed',
+        SCHEDULED = 'scheduled'
 }
+
+export const TASK_DATE_ICONS: Record<keyof TaskDates, string> = {
+        due: '📅',
+        scheduled: '⏳',
+        completed: '✅',
+        created: '🗓️'
+};
 
 export interface SortOption {
 	field: 'urgency' | 'description' | 'created' | 'modified' | 'due' | 'name' | 'recency';

--- a/src/views/task-assignment-view.ts
+++ b/src/views/task-assignment-view.ts
@@ -1,6 +1,6 @@
 import { WorkspaceLeaf, setIcon } from 'obsidian';
 import { TaskAssignmentViewBase } from './task-assignment-view-base';
-import { TaskData, ViewLayout, TaskStatus, TaskPriority, DateType, ViewFilters } from '../types';
+import { TaskData, ViewLayout, TaskStatus, TaskPriority, DateType, ViewFilters, TASK_DATE_ICONS } from '../types';
 import { TaskCacheService } from '../services/task-cache.service';
 import { ViewConfigurationService } from '../services/view-configuration.service';
 import { SaveViewModal } from '../modals/save-view-modal';
@@ -525,14 +525,24 @@ export class TaskAssignmentView extends TaskAssignmentViewBase {
 		// Task metadata
 		const metadataEl = contentEl.createDiv('task-assignment-card-metadata');
 		
-		// Due date
-		if (task.dates.due) {
-			const dueDateEl = metadataEl.createSpan('task-assignment-card-due-date');
-			dueDateEl.setText(this.formatDate(task.dates.due));
-			if (this.isOverdue(task.dates.due)) {
-				dueDateEl.addClass('overdue');
-			}
-		}
+                // Dates
+                if (task.dates.due) {
+                        const dueDateEl = metadataEl.createSpan('task-assignment-card-due-date');
+                        dueDateEl.setText(`${TASK_DATE_ICONS.due} ${this.formatDate(task.dates.due)}`);
+                        if (this.isOverdue(task.dates.due)) {
+                                dueDateEl.addClass('overdue');
+                        }
+                }
+
+                if (task.dates.scheduled) {
+                        const scheduledEl = metadataEl.createSpan('task-assignment-card-scheduled-date');
+                        scheduledEl.setText(`${TASK_DATE_ICONS.scheduled} ${this.formatDate(task.dates.scheduled)}`);
+                }
+
+                if (task.dates.completed) {
+                        const completedEl = metadataEl.createSpan('task-assignment-card-completed-date');
+                        completedEl.setText(`${TASK_DATE_ICONS.completed} ${this.formatDate(task.dates.completed)}`);
+                }
 
 		// Priority indicator
 		if (task.priority !== TaskPriority.MEDIUM) {

--- a/styles/task-assignment-view.css
+++ b/styles/task-assignment-view.css
@@ -462,11 +462,20 @@
 }
 
 .task-assignment-card-due-date {
-	font-size: 12px;
-	color: var(--text-muted);
-	background-color: var(--background-secondary);
-	padding: 2px 6px;
-	border-radius: 4px;
+        font-size: 12px;
+        color: var(--text-muted);
+        background-color: var(--background-secondary);
+        padding: 2px 6px;
+        border-radius: 4px;
+}
+
+.task-assignment-card-scheduled-date,
+.task-assignment-card-completed-date {
+        font-size: 12px;
+        color: var(--text-muted);
+        background-color: var(--background-secondary);
+        padding: 2px 6px;
+        border-radius: 4px;
 }
 
 .task-assignment-card-due-date.overdue {


### PR DESCRIPTION
## Summary
- add date icon constants
- show date icons on task cards
- style scheduled and completed date chips

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686be85afef083299721ff1821f68c4b