### PR TITLE
Add action icons to task cards

### DIFF
--- a/styles/task-assignment-view.css
+++ b/styles/task-assignment-view.css
@@ -489,11 +489,33 @@
 }
 
 .task-assignment-card-tag {
-	font-size: 11px;
-	color: var(--text-accent);
-	background-color: var(--background-secondary);
-	padding: 2px 4px;
-	border-radius: 3px;
+        font-size: 11px;
+        color: var(--text-accent);
+        background-color: var(--background-secondary);
+        padding: 2px 4px;
+        border-radius: 3px;
+}
+
+/* Action icons row */
+.task-assignment-card-actions {
+        display: flex;
+        gap: 8px;
+        margin-top: 4px;
+        align-items: center;
+}
+
+.task-card-action-icon {
+        width: 16px;
+        height: 16px;
+        color: var(--text-muted);
+}
+
+.task-card-action-icon.clickable {
+        cursor: pointer;
+}
+
+.task-card-action-icon.clickable:hover {
+        color: var(--text-normal);
 }
 
 /* Task Status Classes */


### PR DESCRIPTION
## Summary
- add priority, file link, edit, and assignment icons to each task card
- link new icons to actions such as opening the file or assignment modal
- expose helper methods to open files and edit tasks
- style the icons row in the task card CSS

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686beaa0ba4c8329891d93346c698738