### PR TITLE
Optimize cache refresh by parallel file processing

### DIFF
--- a/src/services/task-cache.service.ts
+++ b/src/services/task-cache.service.ts
@@ -57,16 +57,18 @@ export class TaskCacheService {
 		this.isUpdating = true;
 		new Notice('Refreshing task cache...');
 		
-		try {
-			this.cache.clear();
-			
-			const markdownFiles = this.app.vault.getMarkdownFiles();
-			for (const file of markdownFiles) {
-				await this.updateTasksFromFile(file);
-			}
-			
-			await this.saveCacheToFile();
-			new Notice('Task cache refreshed successfully');
+                try {
+                        this.cache.clear();
+
+                        const markdownFiles = this.app.vault.getMarkdownFiles();
+                        await Promise.all(markdownFiles.map(file =>
+                                this.updateTasksFromFile(file).catch(error => {
+                                        console.error(`Error updating tasks from file ${file.path}:`, error);
+                                })
+                        ));
+
+                        await this.saveCacheToFile();
+                        new Notice('Task cache refreshed successfully');
 		} catch (error) {
 			console.error('Error refreshing cache:', error);
 			new Notice('Error refreshing task cache');


### PR DESCRIPTION
## Summary
- use `Promise.all` in `refreshCache` to update tasks from all markdown files concurrently
- retain per-file error handling when refreshing cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c2418a0408329a60a5f6e0e179e4c