### PR TITLE
Add cached search text for faster filtering

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,16 +29,17 @@ export interface ParsedAssignment {
 
 // Task data structures for caching and views
 export interface TaskData {
-	id: string;
-	filePath: string;
-	lineNumber: number;
-	content: string;
-	description: string;
-	status: TaskStatus;
-	priority: TaskPriority;
-	tags: string[];
-	assignments: ParsedAssignment[];
-	dates: TaskDates;
+        id: string;
+        filePath: string;
+        lineNumber: number;
+        content: string;
+        description: string;
+        searchText: string;
+        status: TaskStatus;
+        priority: TaskPriority;
+        tags: string[];
+        assignments: ParsedAssignment[];
+        dates: TaskDates;
 	createdDate: Date;
 	modifiedDate: Date;
 }

--- a/src/views/task-assignment-view-base.ts
+++ b/src/views/task-assignment-view-base.ts
@@ -132,20 +132,13 @@ export abstract class TaskAssignmentViewBase extends ItemView {
 				}
 			}
 
-			// Text search filter
-			if (this.currentFilters.textSearch && this.currentFilters.textSearch.trim()) {
-				const searchTerm = this.currentFilters.textSearch.toLowerCase();
-				const searchableText = [
-					task.description,
-					task.filePath,
-					...task.tags,
-					...task.assignments.flatMap(a => a.assignees)
-				].join(' ').toLowerCase();
-				
-				if (!searchableText.includes(searchTerm)) {
-					return false;
-				}
-			}
+                        // Text search filter
+                        if (this.currentFilters.textSearch && this.currentFilters.textSearch.trim()) {
+                                const searchTerm = this.currentFilters.textSearch.toLowerCase();
+                                if (!task.searchText.includes(searchTerm)) {
+                                        return false;
+                                }
+                        }
 
 			return true;
 		});


### PR DESCRIPTION
## Summary
- extend `TaskData` with a `searchText` property
- generate `searchText` while parsing tasks and when reading the cache
- cache generation helper `buildSearchText`
- use cached `searchText` in filter logic

## Testing
- `npm test`
- `npm run lint:ts` *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_686c245887988329b7d25835a68ce0b5