### PR TITLE
Add debug setting

### DIFF
--- a/dist-test/types/index.js
+++ b/dist-test/types/index.js
@@ -26,6 +26,12 @@ export var DateType;
     DateType["COMPLETED"] = "completed";
     DateType["SCHEDULED"] = "scheduled";
 })(DateType || (DateType = {}));
+export const TASK_DATE_ICONS = {
+    due: '📅',
+    scheduled: '⏳',
+    completed: '✅',
+    created: '🗓️'
+};
 export const DEFAULT_ROLES = [
     { id: 'drivers', name: 'Drivers', icon: '🚗', isDefault: true, order: 1 },
     { id: 'approvers', name: 'Approvers', icon: '👍', isDefault: true, order: 2 },
@@ -40,5 +46,6 @@ export const DEFAULT_SETTINGS = {
     roles: DEFAULT_ROLES,
     hiddenDefaultRoles: [],
     savedViews: [],
-    autoApplyFilters: true
+    autoApplyFilters: true,
+    debug: false
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
-import { 
-	Editor, 
-	MarkdownView, 
+import {
+	Editor,
+	MarkdownView,
 	Plugin,
 	WorkspaceLeaf
 } from 'obsidian';
@@ -21,14 +21,14 @@ export default class TaskAssignmentPlugin extends Plugin {
 
 	async onload() {
 		await this.loadSettings();
-		
+
 		// Initialize services
-                this.taskAssignmentService = new TaskAssignmentService(this.app, this.settings);
-                this.taskCacheService = new TaskCacheService(this.app, this.taskAssignmentService, this.getVisibleRoles(), this.settings.debug);
-		
+		this.taskAssignmentService = new TaskAssignmentService(this.app, this.settings);
+		this.taskCacheService = new TaskCacheService(this.app, this.taskAssignmentService, this.getVisibleRoles(), this.settings.debug);
+
 		// Initialize task cache
 		await this.taskCacheService.initializeCache();
-		
+
 		// Register view
 		this.registerView(
 			'task-assignment-view',
@@ -42,7 +42,7 @@ export default class TaskAssignmentPlugin extends Plugin {
 			editorCheckCallback: (checking: boolean, editor: Editor, view: MarkdownView) => {
 				const line = editor.getLine(editor.getCursor().line);
 				const isTask = /^\s*- \[[ x]\]/.test(line);
-				
+
 				if (isTask) {
 					if (!checking) {
 						this.openAssignmentModal(editor);
@@ -89,10 +89,10 @@ export default class TaskAssignmentPlugin extends Plugin {
 
 	async activateView() {
 		const { workspace } = this.app;
-		
+
 		let leaf: WorkspaceLeaf;
 		const leaves = workspace.getLeavesOfType('task-assignment-view');
-		
+
 		if (leaves.length > 0) {
 			// A view is already open, use it
 			leaf = leaves[0];
@@ -101,19 +101,19 @@ export default class TaskAssignmentPlugin extends Plugin {
 			leaf = workspace.getLeaf() || workspace.getRightLeaf(false);
 			await leaf.setViewState({ type: 'task-assignment-view', active: true });
 		}
-		
+
 		// Reveal the leaf
 		workspace.revealLeaf(leaf);
 	}
 
 	async loadSettings() {
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-		
+
 		// Ensure default roles exist and have correct icons
 		const { DEFAULT_ROLES } = await import('./types');
 		for (const defaultRole of DEFAULT_ROLES) {
 			const existingRole = this.settings.roles.find(r => r.id === defaultRole.id);
-			
+
 			if (existingRole) {
 				// Update existing default role with correct icon and other properties
 				existingRole.icon = defaultRole.icon;
@@ -125,26 +125,26 @@ export default class TaskAssignmentPlugin extends Plugin {
 				this.settings.roles.push(defaultRole);
 			}
 		}
-		
+
 		// Sort roles by order
 		this.settings.roles.sort((a, b) => a.order - b.order);
-		
+
 		// Update services with new settings
 		if (this.taskAssignmentService) {
 			this.taskAssignmentService = new TaskAssignmentService(this.app, this.settings);
 		}
-                if (this.taskCacheService) {
-                        this.taskCacheService = new TaskCacheService(this.app, this.taskAssignmentService, this.getVisibleRoles(), this.settings.debug);
-                }
+		if (this.taskCacheService) {
+			this.taskCacheService = new TaskCacheService(this.app, this.taskAssignmentService, this.getVisibleRoles(), this.settings.debug);
+		}
 	}
 
 	async saveSettings() {
 		await this.saveData(this.settings);
 		// Update services with new settings
 		this.taskAssignmentService = new TaskAssignmentService(this.app, this.settings);
-                if (this.taskCacheService) {
-                        this.taskCacheService = new TaskCacheService(this.app, this.taskAssignmentService, this.getVisibleRoles(), this.settings.debug);
-                }
+		if (this.taskCacheService) {
+			this.taskCacheService = new TaskCacheService(this.app, this.taskAssignmentService, this.getVisibleRoles(), this.settings.debug);
+		}
 	}
 
 	openAssignmentModal(editor: Editor) {
@@ -152,7 +152,7 @@ export default class TaskAssignmentPlugin extends Plugin {
 	}
 
 	getVisibleRoles(): Role[] {
-		return this.settings.roles.filter(role => 
+		return this.settings.roles.filter(role =>
 			!role.isDefault || !this.settings.hiddenDefaultRoles.includes(role.id)
 		);
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,8 +23,8 @@ export default class TaskAssignmentPlugin extends Plugin {
 		await this.loadSettings();
 		
 		// Initialize services
-		this.taskAssignmentService = new TaskAssignmentService(this.app, this.settings);
-		this.taskCacheService = new TaskCacheService(this.app, this.taskAssignmentService, this.getVisibleRoles());
+                this.taskAssignmentService = new TaskAssignmentService(this.app, this.settings);
+                this.taskCacheService = new TaskCacheService(this.app, this.taskAssignmentService, this.getVisibleRoles(), this.settings.debug);
 		
 		// Initialize task cache
 		await this.taskCacheService.initializeCache();
@@ -133,18 +133,18 @@ export default class TaskAssignmentPlugin extends Plugin {
 		if (this.taskAssignmentService) {
 			this.taskAssignmentService = new TaskAssignmentService(this.app, this.settings);
 		}
-		if (this.taskCacheService) {
-			this.taskCacheService = new TaskCacheService(this.app, this.taskAssignmentService, this.getVisibleRoles());
-		}
+                if (this.taskCacheService) {
+                        this.taskCacheService = new TaskCacheService(this.app, this.taskAssignmentService, this.getVisibleRoles(), this.settings.debug);
+                }
 	}
 
 	async saveSettings() {
 		await this.saveData(this.settings);
 		// Update services with new settings
 		this.taskAssignmentService = new TaskAssignmentService(this.app, this.settings);
-		if (this.taskCacheService) {
-			this.taskCacheService = new TaskCacheService(this.app, this.taskAssignmentService, this.getVisibleRoles());
-		}
+                if (this.taskCacheService) {
+                        this.taskCacheService = new TaskCacheService(this.app, this.taskAssignmentService, this.getVisibleRoles(), this.settings.debug);
+                }
 	}
 
 	openAssignmentModal(editor: Editor) {

--- a/src/modals/assignee-selector-modal.ts
+++ b/src/modals/assignee-selector-modal.ts
@@ -138,7 +138,9 @@ export class AssigneeSelectorModal extends FuzzySuggestModal<string> {
 			return;
 		}
 
-		console.log("No suggestions for input: ", this.inputEl.value, " with query: ", query, " and query length ", query.length);
+                if (this.plugin.settings.debug) {
+                        console.log("No suggestions for input: ", this.inputEl.value, " with query: ", query, " and query length ", query.length);
+                }
 		if (!query.startsWith(this.plugin.settings.contactSymbol) && !query.startsWith(this.plugin.settings.companySymbol)) {
 			this.emptyStateText = `Start typing with ${this.plugin.settings.contactSymbol} or ${this.plugin.settings.companySymbol}.`;
 			return;
@@ -149,7 +151,9 @@ export class AssigneeSelectorModal extends FuzzySuggestModal<string> {
 			return;
 		}
 
-		console.log("No results, setting noResults to true for ", this.inputEl.value, " with query ", query);
+                if (this.plugin.settings.debug) {
+                        console.log("No results, setting noResults to true for ", this.inputEl.value, " with query ", query);
+                }
 		this.noResults = true;
 
 		// In add mode, show creation hint

--- a/src/modals/assignee-selector-modal.ts
+++ b/src/modals/assignee-selector-modal.ts
@@ -27,7 +27,7 @@ export class AssigneeSelectorModal extends FuzzySuggestModal<string> {
 	private updatePlaceholder() {
 		const contactSymbol = this.plugin.settings.contactSymbol;
 		const companySymbol = this.plugin.settings.companySymbol;
-		
+
 		if (this.options.mode === 'readonly') {
 			this.setPlaceholder(`Type ${contactSymbol}contact or ${companySymbol}company to search.`);
 		} else {
@@ -44,33 +44,33 @@ export class AssigneeSelectorModal extends FuzzySuggestModal<string> {
 	getItems(): string[] {
 		this.currentQuery = this.inputEl.value;
 		const items: string[] = [];
-		
+
 		if (this.currentQuery.startsWith(this.plugin.settings.contactSymbol)) {
 			const searchTerm = this.currentQuery.substring(1).toLowerCase().replace(/\s+/g, ' ').trim();
-			
+
 			// Add existing contacts that match
 			items.push(...this.contacts
 				.filter(contact => contact.toLowerCase().includes(searchTerm))
 				.map(contact => `${this.plugin.settings.contactSymbol}${contact}`)
 			);
-			
+
 			// Add @me as special case
 			if ('me'.includes(searchTerm)) {
 				if (!items.includes(`${this.plugin.settings.contactSymbol}me`)) {
 					items.unshift(`${this.plugin.settings.contactSymbol}me`);
 				}
 			}
-			
+
 		} else if (this.currentQuery.startsWith(this.plugin.settings.companySymbol)) {
 			const searchTerm = this.currentQuery.substring(1).toLowerCase().replace(/\s+/g, ' ').trim();
-			
+
 			// Add existing companies that match
 			items.push(...this.companies
 				.filter(company => company.toLowerCase().includes(searchTerm))
 				.map(company => `${this.plugin.settings.companySymbol}${company}`)
 			);
 		}
-		
+
 		return items;
 	}
 
@@ -80,27 +80,27 @@ export class AssigneeSelectorModal extends FuzzySuggestModal<string> {
 
 	getEmptyStateText(): string {
 		const query = this.currentQuery;
-		
+
 		if (!query.startsWith(this.plugin.settings.contactSymbol) && !query.startsWith(this.plugin.settings.companySymbol)) {
 			return `Start typing with ${this.plugin.settings.contactSymbol} or ${this.plugin.settings.companySymbol}.`;
 		}
-		
+
 		if (this.options.mode === 'readonly') {
 			return 'No results found!';
 		}
-		
+
 		// In add mode, show creation hint
 		if (query.startsWith(this.plugin.settings.contactSymbol)) {
 			return 'No results found, press Enter to create a new contact.';
 		} else if (query.startsWith(this.plugin.settings.companySymbol)) {
 			return 'No results found, press Enter to create a new company.';
 		}
-		
+
 		return 'No results found!';
 	}
 
 	onChooseItem(item: string): void {
-		
+
 		if (this.noResults) {
 			// user pressed ↵ with no matches – create something new
 			// Only allow creation in add mode
@@ -118,7 +118,7 @@ export class AssigneeSelectorModal extends FuzzySuggestModal<string> {
 			// Clear the input but keep modal open
 			this.inputEl.value = '';
 			this.currentQuery = '';
-			
+
 			// Trigger input event to refresh suggestions
 			this.inputEl.dispatchEvent(new Event('input'));
 		}
@@ -138,9 +138,9 @@ export class AssigneeSelectorModal extends FuzzySuggestModal<string> {
 			return;
 		}
 
-                if (this.plugin.settings.debug) {
-                        console.log("No suggestions for input: ", this.inputEl.value, " with query: ", query, " and query length ", query.length);
-                }
+		if (this.plugin.settings.debug) {
+			console.log("No suggestions for input: ", this.inputEl.value, " with query: ", query, " and query length ", query.length);
+		}
 		if (!query.startsWith(this.plugin.settings.contactSymbol) && !query.startsWith(this.plugin.settings.companySymbol)) {
 			this.emptyStateText = `Start typing with ${this.plugin.settings.contactSymbol} or ${this.plugin.settings.companySymbol}.`;
 			return;
@@ -151,9 +151,9 @@ export class AssigneeSelectorModal extends FuzzySuggestModal<string> {
 			return;
 		}
 
-                if (this.plugin.settings.debug) {
-                        console.log("No results, setting noResults to true for ", this.inputEl.value, " with query ", query);
-                }
+		if (this.plugin.settings.debug) {
+			console.log("No results, setting noResults to true for ", this.inputEl.value, " with query ", query);
+		}
 		this.noResults = true;
 
 		// In add mode, show creation hint
@@ -167,7 +167,7 @@ export class AssigneeSelectorModal extends FuzzySuggestModal<string> {
 	close(): void {
 		if (this.options.keepOpen && this.disableClose) {
 			this.emptyStateText = 'Make another selection. All done? ESC or X twice to close.';
-            this.disableClose = false; // Reset the disableClose flag, so the modal can be closed, as long as the user doesn't make another selection
+			this.disableClose = false; // Reset the disableClose flag, so the modal can be closed, as long as the user doesn't make another selection
 			return;  // swallow the auto-close
 		}
 		super.close(); // otherwise shut down normally

--- a/src/services/task-cache.service.ts
+++ b/src/services/task-cache.service.ts
@@ -7,13 +7,14 @@ export class TaskCacheService {
 	private cacheFilePath = '.obsidian/task-assignment-cache.json';
 	private isUpdating = false;
 
-	constructor(
-		private app: App,
-		private taskAssignmentService: TaskAssignmentService,
-		private visibleRoles: Role[]
-	) {
-		this.setupEventListeners();
-	}
+        constructor(
+                private app: App,
+                private taskAssignmentService: TaskAssignmentService,
+                private visibleRoles: Role[],
+                private debug: boolean
+        ) {
+                this.setupEventListeners();
+        }
 
 	private setupEventListeners() {
 		// Listen for file changes
@@ -43,13 +44,15 @@ export class TaskCacheService {
 	}
 
 	async initializeCache(): Promise<void> {
-		try {
-			await this.loadCacheFromFile();
-		} catch (error) {
-			console.log('No existing cache found, building new cache...');
-			await this.refreshCache();
-		}
-	}
+                try {
+                        await this.loadCacheFromFile();
+                } catch (error) {
+                        if (this.debug) {
+                                console.log('No existing cache found, building new cache...');
+                        }
+                        await this.refreshCache();
+                }
+        }
 
 	async refreshCache(): Promise<void> {
 		if (this.isUpdating) return;

--- a/src/services/task-cache.service.ts
+++ b/src/services/task-cache.service.ts
@@ -7,14 +7,14 @@ export class TaskCacheService {
 	private cacheFilePath = '.obsidian/task-assignment-cache.json';
 	private isUpdating = false;
 
-        constructor(
-                private app: App,
-                private taskAssignmentService: TaskAssignmentService,
-                private visibleRoles: Role[],
-                private debug: boolean
-        ) {
-                this.setupEventListeners();
-        }
+	constructor(
+		private app: App,
+		private taskAssignmentService: TaskAssignmentService,
+		private visibleRoles: Role[],
+		private debug: boolean
+	) {
+		this.setupEventListeners();
+	}
 
 	private setupEventListeners() {
 		// Listen for file changes
@@ -44,30 +44,30 @@ export class TaskCacheService {
 	}
 
 	async initializeCache(): Promise<void> {
-                try {
-                        await this.loadCacheFromFile();
-                } catch (error) {
-                        if (this.debug) {
-                                console.log('No existing cache found, building new cache...');
-                        }
-                        await this.refreshCache();
-                }
-        }
+		try {
+			await this.loadCacheFromFile();
+		} catch (error) {
+			if (this.debug) {
+				console.log('No existing cache found, building new cache...');
+			}
+			await this.refreshCache();
+		}
+	}
 
 	async refreshCache(): Promise<void> {
 		if (this.isUpdating) return;
-		
+
 		this.isUpdating = true;
 		new Notice('Refreshing task cache...');
-		
+
 		try {
 			this.cache.clear();
-			
+
 			const markdownFiles = this.app.vault.getMarkdownFiles();
 			for (const file of markdownFiles) {
 				await this.updateTasksFromFile(file);
 			}
-			
+
 			await this.saveCacheToFile();
 			new Notice('Task cache refreshed successfully');
 		} catch (error) {
@@ -82,18 +82,18 @@ export class TaskCacheService {
 		try {
 			const content = await this.app.vault.read(file);
 			const lines = content.split('\n');
-			
+
 			// Remove existing tasks from this file
 			this.removeTasksFromFile(file);
-			
+
 			// Parse tasks from file
 			const fileTasks = this.parseTasksFromContent(file, lines);
-			
+
 			// Add new tasks to cache
 			for (const task of fileTasks) {
 				this.cache.set(task.id, task);
 			}
-			
+
 			// Save cache periodically (debounced)
 			this.debouncedSave();
 		} catch (error) {
@@ -104,7 +104,7 @@ export class TaskCacheService {
 	private removeTasksFromFile(file: TFile): void {
 		const tasksToRemove = Array.from(this.cache.values())
 			.filter(task => task.filePath === file.path);
-		
+
 		for (const task of tasksToRemove) {
 			this.cache.delete(task.id);
 		}
@@ -113,31 +113,31 @@ export class TaskCacheService {
 	private handleFileRename(file: TFile, oldPath: string): void {
 		const tasksToUpdate = Array.from(this.cache.values())
 			.filter(task => task.filePath === oldPath);
-		
+
 		for (const task of tasksToUpdate) {
 			task.filePath = file.path;
 			task.modifiedDate = new Date();
 		}
-		
+
 		this.debouncedSave();
 	}
 
 	private parseTasksFromContent(file: TFile, lines: string[]): TaskData[] {
 		const tasks: TaskData[] = [];
-		
+
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i];
 			const taskMatch = line.match(/^(\s*)[-*+]\s*\[([x\s])\]\s*(.+)$/);
-			
+
 			if (taskMatch) {
-				const [,, statusChar, content] = taskMatch;
+				const [, , statusChar, content] = taskMatch;
 				const task = this.parseTaskFromLine(file, i, line, content, statusChar);
 				if (task) {
 					tasks.push(task);
 				}
 			}
 		}
-		
+
 		return tasks;
 	}
 
@@ -150,27 +150,27 @@ export class TaskCacheService {
 	): TaskData | null {
 		try {
 			const taskId = `${file.path}:${lineNumber}`;
-			
+
 			// Parse status
 			const status = this.parseTaskStatus(statusChar, content);
-			
+
 			// Parse assignments
 			const assignments = this.taskAssignmentService.parseTaskAssignments(content, this.visibleRoles);
-			
+
 			// Parse description (remove assignments and metadata)
 			const description = this.extractTaskDescription(content);
-			
+
 			// Parse priority and tags
 			const priority = this.parseTaskPriority(content);
 			const tags = this.parseTaskTags(content);
-			
+
 			// Parse dates
 			const dates = this.parseTaskDates(content);
-			
+
 			// Get file dates
 			const createdDate = new Date(file.stat.ctime);
 			const modifiedDate = new Date(file.stat.mtime);
-			
+
 			return {
 				id: taskId,
 				filePath: file.path,
@@ -195,16 +195,16 @@ export class TaskCacheService {
 		if (statusChar === 'x' || statusChar === 'X') {
 			return TaskStatus.DONE;
 		}
-		
+
 		// Check for custom status indicators in content
 		if (content.includes('🚧') || content.includes('[in-progress]')) {
 			return TaskStatus.IN_PROGRESS;
 		}
-		
+
 		if (content.includes('❌') || content.includes('[cancelled]')) {
 			return TaskStatus.CANCELLED;
 		}
-		
+
 		return TaskStatus.TODO;
 	}
 
@@ -212,15 +212,15 @@ export class TaskCacheService {
 		if (content.includes('🔴') || content.includes('[urgent]') || content.includes('!!!')) {
 			return TaskPriority.URGENT;
 		}
-		
+
 		if (content.includes('🟡') || content.includes('[high]') || content.includes('!!')) {
 			return TaskPriority.HIGH;
 		}
-		
+
 		if (content.includes('🟢') || content.includes('[low]')) {
 			return TaskPriority.LOW;
 		}
-		
+
 		return TaskPriority.MEDIUM;
 	}
 
@@ -232,7 +232,7 @@ export class TaskCacheService {
 
 	private parseTaskDates(content: string): TaskDates {
 		const dates: TaskDates = {};
-		
+
 		// Parse various date formats
 		const datePatterns = [
 			{ type: 'due', pattern: /due:\s*(\d{4}-\d{2}-\d{2})/i },
@@ -241,7 +241,7 @@ export class TaskCacheService {
 			{ type: 'due', pattern: /📅\s*(\d{4}-\d{2}-\d{2})/i },
 			{ type: 'due', pattern: /\[due::\s*(\d{4}-\d{2}-\d{2})\]/i }
 		];
-		
+
 		for (const { type, pattern } of datePatterns) {
 			const match = content.match(pattern);
 			if (match) {
@@ -252,20 +252,20 @@ export class TaskCacheService {
 				}
 			}
 		}
-		
+
 		return dates;
 	}
 
 	private extractTaskDescription(content: string): string {
 		// Remove assignments, dates, priority indicators, and tags
 		let description = content;
-		
+
 		// Remove role assignments
 		for (const role of this.visibleRoles) {
 			const regex = new RegExp(`\\s*${this.taskAssignmentService.escapeRegex(role.icon)}\\s+[^${this.visibleRoles.map(r => this.taskAssignmentService.escapeRegex(r.icon)).join('')}]*`, 'gu');
 			description = description.replace(regex, '');
 		}
-		
+
 		// Remove dates, priority, and tags
 		description = description
 			.replace(/\s*(due|scheduled|completed):\s*\d{4}-\d{2}-\d{2}/gi, '')
@@ -276,7 +276,7 @@ export class TaskCacheService {
 			.replace(/\s*!{1,3}/g, '')
 			.replace(/\s*#[\w-]+/g, '')
 			.trim();
-		
+
 		return description;
 	}
 
@@ -286,7 +286,7 @@ export class TaskCacheService {
 		if (this.saveTimeout) {
 			clearTimeout(this.saveTimeout);
 		}
-		
+
 		this.saveTimeout = setTimeout(() => {
 			this.saveCacheToFile();
 		}, 1000);
@@ -309,7 +309,7 @@ export class TaskCacheService {
 					}
 				}))
 			};
-			
+
 			await this.app.vault.adapter.write(this.cacheFilePath, JSON.stringify(cacheData, null, 2));
 		} catch (error) {
 			console.error('Error saving cache to file:', error);
@@ -320,10 +320,10 @@ export class TaskCacheService {
 		try {
 			const cacheContent = await this.app.vault.adapter.read(this.cacheFilePath);
 			const cacheData = JSON.parse(cacheContent);
-			
+
 			if (cacheData.version === 1 && cacheData.tasks) {
 				this.cache.clear();
-				
+
 				for (const taskData of cacheData.tasks) {
 					const task: TaskData = {
 						...taskData,
@@ -336,7 +336,7 @@ export class TaskCacheService {
 							scheduled: taskData.dates.scheduled ? new Date(taskData.dates.scheduled) : undefined
 						}
 					};
-					
+
 					this.cache.set(task.id, task);
 				}
 			}
@@ -361,22 +361,22 @@ export class TaskCacheService {
 	async updateTaskStatus(taskId: string, newStatus: TaskStatus): Promise<void> {
 		const task = this.cache.get(taskId);
 		if (!task) return;
-		
+
 		try {
 			const file = this.app.vault.getAbstractFileByPath(task.filePath);
 			if (!file || !(file instanceof TFile)) return;
-			
+
 			const content = await this.app.vault.read(file);
 			const lines = content.split('\n');
-			
+
 			if (task.lineNumber < lines.length) {
 				const line = lines[task.lineNumber];
 				const statusChar = newStatus === TaskStatus.DONE ? 'x' : ' ';
 				const newLine = line.replace(/^(\s*[-*+]\s*\[)[x\s](\]\s*.+)$/, `$1${statusChar}$2`);
-				
+
 				lines[task.lineNumber] = newLine;
 				await this.app.vault.modify(file, lines.join('\n'));
-				
+
 				// Update cache
 				task.status = newStatus;
 				task.modifiedDate = new Date();

--- a/src/settings/task-assignment-settings-tab.ts
+++ b/src/settings/task-assignment-settings-tab.ts
@@ -66,25 +66,25 @@ export class TaskAssignmentSettingTab extends PluginSettingTab {
 				}));
 
 		// Create @me contact button
-                new Setting(containerEl)
-                        .setName('Create @me contact')
-                        .setDesc('Create a special contact file for yourself')
-                        .addButton(button => button
-                                .setButtonText('Create @me')
-                                .onClick(async () => {
-                                        await this.plugin.taskAssignmentService.createMeContact();
-                                }));
+		new Setting(containerEl)
+			.setName('Create @me contact')
+			.setDesc('Create a special contact file for yourself')
+			.addButton(button => button
+				.setButtonText('Create @me')
+				.onClick(async () => {
+					await this.plugin.taskAssignmentService.createMeContact();
+				}));
 
-                // Debug logging toggle
-                new Setting(containerEl)
-                        .setName('Enable debug logging')
-                        .setDesc('Log additional information to the console')
-                        .addToggle(toggle => toggle
-                                .setValue(this.plugin.settings.debug)
-                                .onChange(async (value) => {
-                                        this.plugin.settings.debug = value;
-                                        await this.plugin.saveSettings();
-                                }));
+		// Debug logging toggle
+		new Setting(containerEl)
+			.setName('Enable debug logging')
+			.setDesc('Log additional information to the console')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.debug)
+				.onChange(async (value) => {
+					this.plugin.settings.debug = value;
+					await this.plugin.saveSettings();
+				}));
 
 		// Role management
 		containerEl.createEl('h3', { text: 'Role management' });
@@ -103,7 +103,7 @@ export class TaskAssignmentSettingTab extends PluginSettingTab {
 								this.plugin.settings.hiddenDefaultRoles.push(role.id);
 							}
 						} else {
-							this.plugin.settings.hiddenDefaultRoles = 
+							this.plugin.settings.hiddenDefaultRoles =
 								this.plugin.settings.hiddenDefaultRoles.filter(id => id !== role.id);
 						}
 						await this.plugin.saveSettings();
@@ -175,7 +175,7 @@ export class TaskAssignmentSettingTab extends PluginSettingTab {
 
 						this.plugin.settings.roles.push(newRole);
 						await this.plugin.saveSettings();
-						
+
 						nameInput.value = '';
 						iconInput.value = '';
 						this.display();

--- a/src/settings/task-assignment-settings-tab.ts
+++ b/src/settings/task-assignment-settings-tab.ts
@@ -66,14 +66,25 @@ export class TaskAssignmentSettingTab extends PluginSettingTab {
 				}));
 
 		// Create @me contact button
-		new Setting(containerEl)
-			.setName('Create @me contact')
-			.setDesc('Create a special contact file for yourself')
-			.addButton(button => button
-				.setButtonText('Create @me')
-				.onClick(async () => {
-					await this.plugin.taskAssignmentService.createMeContact();
-				}));
+                new Setting(containerEl)
+                        .setName('Create @me contact')
+                        .setDesc('Create a special contact file for yourself')
+                        .addButton(button => button
+                                .setButtonText('Create @me')
+                                .onClick(async () => {
+                                        await this.plugin.taskAssignmentService.createMeContact();
+                                }));
+
+                // Debug logging toggle
+                new Setting(containerEl)
+                        .setName('Enable debug logging')
+                        .setDesc('Log additional information to the console')
+                        .addToggle(toggle => toggle
+                                .setValue(this.plugin.settings.debug)
+                                .onChange(async (value) => {
+                                        this.plugin.settings.debug = value;
+                                        await this.plugin.saveSettings();
+                                }));
 
 		// Role management
 		containerEl.createEl('h3', { text: 'Role management' });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,12 +1,13 @@
 export interface TaskAssignmentSettings {
-	contactSymbol: string;
-	companySymbol: string;
-	contactDirectory: string;
-	companyDirectory: string;
-	roles: Role[];
-	hiddenDefaultRoles: string[];
-	savedViews: ViewConfiguration[];
-	autoApplyFilters: boolean;
+        contactSymbol: string;
+        companySymbol: string;
+        contactDirectory: string;
+        companyDirectory: string;
+        roles: Role[];
+        hiddenDefaultRoles: string[];
+        savedViews: ViewConfiguration[];
+        autoApplyFilters: boolean;
+        debug: boolean;
 }
 
 export interface Role {
@@ -139,7 +140,8 @@ export const DEFAULT_SETTINGS: TaskAssignmentSettings = {
 	contactDirectory: 'Contacts',
 	companyDirectory: 'Companies',
 	roles: DEFAULT_ROLES,
-	hiddenDefaultRoles: [],
-	savedViews: [],
-	autoApplyFilters: true
-}; 
+        hiddenDefaultRoles: [],
+        savedViews: [],
+        autoApplyFilters: true,
+        debug: false
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,13 +1,13 @@
 export interface TaskAssignmentSettings {
-        contactSymbol: string;
-        companySymbol: string;
-        contactDirectory: string;
-        companyDirectory: string;
-        roles: Role[];
-        hiddenDefaultRoles: string[];
-        savedViews: ViewConfiguration[];
-        autoApplyFilters: boolean;
-        debug: boolean;
+	contactSymbol: string;
+	companySymbol: string;
+	contactDirectory: string;
+	companyDirectory: string;
+	roles: Role[];
+	hiddenDefaultRoles: string[];
+	savedViews: ViewConfiguration[];
+	autoApplyFilters: boolean;
+	debug: boolean;
 }
 
 export interface Role {
@@ -140,8 +140,8 @@ export const DEFAULT_SETTINGS: TaskAssignmentSettings = {
 	contactDirectory: 'Contacts',
 	companyDirectory: 'Companies',
 	roles: DEFAULT_ROLES,
-        hiddenDefaultRoles: [],
-        savedViews: [],
-        autoApplyFilters: true,
-        debug: false
+	hiddenDefaultRoles: [],
+	savedViews: [],
+	autoApplyFilters: true,
+	debug: false
 };


### PR DESCRIPTION
## Summary
- add `debug` setting to plugin
- expose a toggle for debug logs in plugin settings
- gate existing console logs on debug mode

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_686c24ec3c788329b30fff1938e1517c