### PR TITLE
Fix async cache refresh errors

### DIFF
--- a/dist-test/services/task-assignment.service.js
+++ b/dist-test/services/task-assignment.service.js
@@ -8,7 +8,7 @@ export class TaskAssignmentService {
         this.companyCache = [];
         this.cacheInitialized = false;
         // Build initial cache and listen for file system changes
-        void this.refreshAssigneeCache();
+        this.refreshAssigneeCache().catch(error => console.error('Error refreshing assignee cache:', error));
         this.setupCacheWatchers();
     }
     setupCacheWatchers() {
@@ -18,7 +18,7 @@ export class TaskAssignmentService {
             const path = file.path;
             if (path.startsWith(`${this.settings.contactDirectory}/`) ||
                 path.startsWith(`${this.settings.companyDirectory}/`)) {
-                void this.refreshAssigneeCache();
+                this.refreshAssigneeCache().catch(error => console.error('Error refreshing assignee cache:', error));
             }
         };
         if (typeof this.app.vault.on === 'function') {
@@ -48,11 +48,11 @@ export class TaskAssignmentService {
             this.cacheInitialized = true;
             return;
         }
-        this.contactCache = await this.readDirectory(this.settings.contactDirectory);
-        this.companyCache = await this.readDirectory(this.settings.companyDirectory);
+        this.contactCache = this.readDirectory(this.settings.contactDirectory);
+        this.companyCache = this.readDirectory(this.settings.companyDirectory);
         this.cacheInitialized = true;
     }
-    async readDirectory(directory) {
+    readDirectory(directory) {
         const folder = this.app.vault.getAbstractFileByPath(directory);
         if (!folder || !(folder instanceof TFolder)) {
             return [];
@@ -99,10 +99,10 @@ export class TaskAssignmentService {
         const sortedAssignments = assignments
             .filter(a => a.assignees.length > 0)
             .sort((a, b) => {
-                const roleA = visibleRoles.find(r => r.id === a.roleId);
-                const roleB = visibleRoles.find(r => r.id === b.roleId);
-                return (roleA?.order || 999) - (roleB?.order || 999);
-            });
+            const roleA = visibleRoles.find(r => r.id === a.roleId);
+            const roleB = visibleRoles.find(r => r.id === b.roleId);
+            return (roleA?.order || 999) - (roleB?.order || 999);
+        });
         for (const assignment of sortedAssignments) {
             const role = visibleRoles.find(r => r.id === assignment.roleId);
             if (role) {

--- a/src/services/task-assignment.service.ts
+++ b/src/services/task-assignment.service.ts
@@ -6,21 +6,27 @@ export class TaskAssignmentService {
 	private companyCache: string[] = [];
 	private cacheInitialized = false;
 
-	constructor(private app: App, private settings: TaskAssignmentSettings) {
-		// Build initial cache and listen for file system changes
-		void this.refreshAssigneeCache();
-		this.setupCacheWatchers();
-	}
+        constructor(private app: App, private settings: TaskAssignmentSettings) {
+                // Build initial cache and listen for file system changes
+                this.refreshAssigneeCache().catch(error =>
+                        console.error('Error refreshing assignee cache:', error)
+                );
+                this.setupCacheWatchers();
+        }
 
 	private setupCacheWatchers(): void {
-		const refresh = (file: TFile) => {
-			if (file.extension !== 'md') return;
-			const path = file.path;
-			if (path.startsWith(`${this.settings.contactDirectory}/`) ||
-				path.startsWith(`${this.settings.companyDirectory}/`)) {
-				void this.refreshAssigneeCache();
-			}
-		};
+                const refresh = (file: TFile) => {
+                        if (file.extension !== 'md') return;
+                        const path = file.path;
+                        if (
+                                path.startsWith(`${this.settings.contactDirectory}/`) ||
+                                path.startsWith(`${this.settings.companyDirectory}/`)
+                        ) {
+                                this.refreshAssigneeCache().catch(error =>
+                                        console.error('Error refreshing assignee cache:', error)
+                                );
+                        }
+                };
 
 		if (typeof (this.app.vault as any).on === 'function') {
 			this.app.vault.on('create', refresh);
@@ -55,16 +61,16 @@ export class TaskAssignmentService {
 			return;
 		}
 
-		this.contactCache = await this.readDirectory(this.settings.contactDirectory);
-		this.companyCache = await this.readDirectory(this.settings.companyDirectory);
-		this.cacheInitialized = true;
-	}
+                this.contactCache = this.readDirectory(this.settings.contactDirectory);
+                this.companyCache = this.readDirectory(this.settings.companyDirectory);
+                this.cacheInitialized = true;
+        }
 
-	private async readDirectory(directory: string): Promise<string[]> {
-		const folder = this.app.vault.getAbstractFileByPath(directory);
-		if (!folder || !(folder instanceof TFolder)) {
-			return [];
-		}
+        private readDirectory(directory: string): string[] {
+                const folder = this.app.vault.getAbstractFileByPath(directory);
+                if (!folder || !(folder instanceof TFolder)) {
+                        return [];
+                }
 
 		const files: string[] = [];
 		for (const file of folder.children) {
@@ -73,8 +79,8 @@ export class TaskAssignmentService {
 			}
 		}
 
-		return files.sort();
-	}
+                return files.sort();
+        }
 
 	parseTaskAssignments(taskText: string, visibleRoles: Role[]): ParsedAssignment[] {
 		const assignments: ParsedAssignment[] = [];


### PR DESCRIPTION
## Summary
- improve error handling when refreshing assignee caches
- remove unused async logic in `readDirectory`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ce36bde0c83298a7c6a9a4b0be115