### PR TITLE
Add role autosuggest shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Assign contacts, companies and roles to tasks using DACI (Driver, Approver, Cont
 - **Approvers** 👍: Who needs to approve the task
 - **Contributors** 👥: Who will contribute to the task
 - **Informed** 📢: Who needs to be kept informed
+- **Quick shortcuts**: Type `\d`, `\a`, `\c` or `\i` to insert role fields. Custom roles can define their own letter.
 
 ### ⚙️ Customizable Roles
 

--- a/dist-test/types/index.js
+++ b/dist-test/types/index.js
@@ -33,10 +33,10 @@ export const TASK_DATE_ICONS = {
     created: '🗓️'
 };
 export const DEFAULT_ROLES = [
-    { id: 'drivers', name: 'Drivers', icon: '🚗', isDefault: true, order: 1 },
-    { id: 'approvers', name: 'Approvers', icon: '👍', isDefault: true, order: 2 },
-    { id: 'contributors', name: 'Contributors', icon: '👥', isDefault: true, order: 3 },
-    { id: 'informed', name: 'Informed', icon: '📢', isDefault: true, order: 4 }
+    { id: 'drivers', name: 'Drivers', icon: '🚗', shortcut: 'd', isDefault: true, order: 1 },
+    { id: 'approvers', name: 'Approvers', icon: '👍', shortcut: 'a', isDefault: true, order: 2 },
+    { id: 'contributors', name: 'Contributors', icon: '👥', shortcut: 'c', isDefault: true, order: 3 },
+    { id: 'informed', name: 'Informed', icon: '📢', shortcut: 'i', isDefault: true, order: 4 }
 ];
 export const DEFAULT_SETTINGS = {
     contactSymbol: '@',

--- a/src/editor/role-suggest.ts
+++ b/src/editor/role-suggest.ts
@@ -1,0 +1,60 @@
+import {
+    App,
+    Editor,
+    EditorPosition,
+    EditorSuggest,
+    EditorSuggestContext,
+    EditorSuggestTriggerInfo
+} from 'obsidian';
+import type TaskAssignmentPlugin from '../main';
+import { Role } from '../types';
+
+/**
+ * Suggests roles when typing a backslash followed by the role shortcut.
+ * Inserts a dataview inline field like `[🚗:: ]` with the cursor positioned
+ * before the closing bracket.
+ */
+export class RoleSuggest extends EditorSuggest<Role> {
+    constructor(public app: App, private plugin: TaskAssignmentPlugin) {
+        super(app);
+    }
+
+    onTrigger(cursor: EditorPosition, editor: Editor): EditorSuggestTriggerInfo | null {
+        const line = editor.getLine(cursor.line);
+        const before = line.substring(0, cursor.ch);
+        const match = before.match(/\\([a-zA-Z]*)$/);
+        if (!match) {
+            return null;
+        }
+
+        const query = match[1];
+        const start = cursor.ch - query.length - 1; // include backslash
+        return {
+            start: { line: cursor.line, ch: start },
+            end: cursor,
+            query
+        };
+    }
+
+    getSuggestions(context: EditorSuggestContext): Role[] {
+        const query = context.query.toLowerCase();
+        const roles = this.plugin.getVisibleRoles();
+        return roles.filter(r => (r.shortcut ?? '').toLowerCase().startsWith(query));
+    }
+
+    renderSuggestion(role: Role, el: HTMLElement): void {
+        el.createSpan({ text: `${role.icon} ${role.name}` });
+    }
+
+    selectSuggestion(role: Role): void {
+        const { editor, start } = this.context!;
+        const replacement = `[${role.icon}:: ]`;
+        editor.replaceRange(replacement, start, this.context!.end);
+        const cursorPos = {
+            line: start.line,
+            ch: start.ch + replacement.length - 1
+        };
+        editor.setCursor(cursorPos);
+    }
+}
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,9 @@
 import {
-        Editor,
-        EditorPosition,
-        MarkdownView,
-        Plugin,
-        WorkspaceLeaf
+	Editor,
+	EditorPosition,
+	MarkdownView,
+	Plugin,
+	WorkspaceLeaf
 } from 'obsidian';
 
 import { TaskAssignmentSettings, DEFAULT_SETTINGS, Role } from './types';
@@ -72,30 +72,30 @@ export default class TaskAssignmentPlugin extends Plugin {
 			}
 		});
 
-                // Register editor suggest for inline assignment
-                this.registerEditorSuggest(new AssignmentSuggest(this.app, this));
+		// Register editor suggest for inline assignment
+		this.registerEditorSuggest(new AssignmentSuggest(this.app, this));
 
-                // Register role suggestion for \ shortcuts
-                this.registerEditorSuggest(new RoleSuggest(this.app, this));
+		// Register role suggestion for \ shortcuts
+		this.registerEditorSuggest(new RoleSuggest(this.app, this));
 
-                // Integrate with the Tasks plugin autosuggest menu if available
-                const tasks = this.app.plugins.enabledPlugins.has('obsidian-tasks-plugin')
-                        ? (this.app.plugins.plugins['obsidian-tasks-plugin'] as any).apiV1
-                        : undefined;
+		// Integrate with the Tasks plugin autosuggest menu if available
+		const tasks = this.app.plugins.enabledPlugins.has('obsidian-tasks-plugin')
+			? (this.app.plugins.plugins['obsidian-tasks-plugin'] as any).apiV1
+			: undefined;
 
-                if (tasks?.registerAutoSuggestExtension) {
-                        for (const role of this.getVisibleRoles()) {
-                                tasks.registerAutoSuggestExtension({
-                                        keyword: role.id,
-                                        icon: role.icon,
-                                        onApply: ({ editor, range }: { editor: Editor; range: { from: EditorPosition; to: EditorPosition } }) => {
-                                                const replacement = `[${role.icon}:: ]`;
-                                                editor.replaceRange(replacement, range.from, range.to);
-                                                editor.setCursor({ line: range.from.line, ch: range.from.ch + replacement.length - 1 });
-                                        }
-                                });
-                        }
-                }
+		if (tasks?.registerAutoSuggestExtension) {
+			for (const role of this.getVisibleRoles()) {
+				tasks.registerAutoSuggestExtension({
+					keyword: role.id,
+					icon: role.icon,
+					onApply: ({ editor, range }: { editor: Editor; range: { from: EditorPosition; to: EditorPosition } }) => {
+						const replacement = `[${role.icon}:: ]`;
+						editor.replaceRange(replacement, range.from, range.to);
+						editor.setCursor({ line: range.from.line, ch: range.from.ch + replacement.length - 1 });
+					}
+				});
+			}
+		}
 
 		// Register the CodeMirror extension for task icons
 		this.registerEditorExtension(taskAssignmentExtension(this));
@@ -133,22 +133,22 @@ export default class TaskAssignmentPlugin extends Plugin {
 	async loadSettings() {
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
 
-                // Ensure default roles exist and have correct icons and shortcuts
-                const { DEFAULT_ROLES } = await import('./types');
-                for (const defaultRole of DEFAULT_ROLES) {
-                        const existingRole = this.settings.roles.find(r => r.id === defaultRole.id);
+		// Ensure default roles exist and have correct icons and shortcuts
+		const { DEFAULT_ROLES } = await import('./types');
+		for (const defaultRole of DEFAULT_ROLES) {
+			const existingRole = this.settings.roles.find(r => r.id === defaultRole.id);
 
-                        if (existingRole) {
-                                // Update existing default role with correct icon and other properties
-                                existingRole.icon = defaultRole.icon;
-                                existingRole.name = defaultRole.name;
-                                existingRole.shortcut = defaultRole.shortcut;
-                                existingRole.isDefault = defaultRole.isDefault;
-                                existingRole.order = defaultRole.order;
-                        } else if (!this.settings.hiddenDefaultRoles.includes(defaultRole.id)) {
-                                // Add missing default role if not hidden
-                                this.settings.roles.push(defaultRole);
-                        }
+			if (existingRole) {
+				// Update existing default role with correct icon and other properties
+				existingRole.icon = defaultRole.icon;
+				existingRole.name = defaultRole.name;
+				existingRole.shortcut = defaultRole.shortcut;
+				existingRole.isDefault = defaultRole.isDefault;
+				existingRole.order = defaultRole.order;
+			} else if (!this.settings.hiddenDefaultRoles.includes(defaultRole.id)) {
+				// Add missing default role if not hidden
+				this.settings.roles.push(defaultRole);
+			}
 		}
 
 		// Sort roles by order

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
 import {
-	Editor,
-	MarkdownView,
-	Plugin,
-	WorkspaceLeaf
+        Editor,
+        EditorPosition,
+        MarkdownView,
+        Plugin,
+        WorkspaceLeaf
 } from 'obsidian';
 
 import { TaskAssignmentSettings, DEFAULT_SETTINGS, Role } from './types';
@@ -10,6 +11,7 @@ import { TaskAssignmentService } from './services/task-assignment.service';
 import { TaskCacheService } from './services/task-cache.service';
 import { taskAssignmentExtension } from './editor/task-assignment-extension';
 import { AssignmentSuggest } from './editor/assignment-suggest';
+import { RoleSuggest } from './editor/role-suggest';
 import { AssignmentModal } from './modals/assignment-modal';
 import { TaskAssignmentSettingTab } from './settings/task-assignment-settings-tab';
 import { TaskAssignmentView } from './views/task-assignment-view';
@@ -70,8 +72,30 @@ export default class TaskAssignmentPlugin extends Plugin {
 			}
 		});
 
-		// Register editor suggest for inline assignment
-		this.registerEditorSuggest(new AssignmentSuggest(this.app, this));
+                // Register editor suggest for inline assignment
+                this.registerEditorSuggest(new AssignmentSuggest(this.app, this));
+
+                // Register role suggestion for \ shortcuts
+                this.registerEditorSuggest(new RoleSuggest(this.app, this));
+
+                // Integrate with the Tasks plugin autosuggest menu if available
+                const tasks = this.app.plugins.enabledPlugins.has('obsidian-tasks-plugin')
+                        ? (this.app.plugins.plugins['obsidian-tasks-plugin'] as any).apiV1
+                        : undefined;
+
+                if (tasks?.registerAutoSuggestExtension) {
+                        for (const role of this.getVisibleRoles()) {
+                                tasks.registerAutoSuggestExtension({
+                                        keyword: role.id,
+                                        icon: role.icon,
+                                        onApply: ({ editor, range }: { editor: Editor; range: { from: EditorPosition; to: EditorPosition } }) => {
+                                                const replacement = `[${role.icon}:: ]`;
+                                                editor.replaceRange(replacement, range.from, range.to);
+                                                editor.setCursor({ line: range.from.line, ch: range.from.ch + replacement.length - 1 });
+                                        }
+                                });
+                        }
+                }
 
 		// Register the CodeMirror extension for task icons
 		this.registerEditorExtension(taskAssignmentExtension(this));
@@ -109,21 +133,22 @@ export default class TaskAssignmentPlugin extends Plugin {
 	async loadSettings() {
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
 
-		// Ensure default roles exist and have correct icons
-		const { DEFAULT_ROLES } = await import('./types');
-		for (const defaultRole of DEFAULT_ROLES) {
-			const existingRole = this.settings.roles.find(r => r.id === defaultRole.id);
+                // Ensure default roles exist and have correct icons and shortcuts
+                const { DEFAULT_ROLES } = await import('./types');
+                for (const defaultRole of DEFAULT_ROLES) {
+                        const existingRole = this.settings.roles.find(r => r.id === defaultRole.id);
 
-			if (existingRole) {
-				// Update existing default role with correct icon and other properties
-				existingRole.icon = defaultRole.icon;
-				existingRole.name = defaultRole.name;
-				existingRole.isDefault = defaultRole.isDefault;
-				existingRole.order = defaultRole.order;
-			} else if (!this.settings.hiddenDefaultRoles.includes(defaultRole.id)) {
-				// Add missing default role if not hidden
-				this.settings.roles.push(defaultRole);
-			}
+                        if (existingRole) {
+                                // Update existing default role with correct icon and other properties
+                                existingRole.icon = defaultRole.icon;
+                                existingRole.name = defaultRole.name;
+                                existingRole.shortcut = defaultRole.shortcut;
+                                existingRole.isDefault = defaultRole.isDefault;
+                                existingRole.order = defaultRole.order;
+                        } else if (!this.settings.hiddenDefaultRoles.includes(defaultRole.id)) {
+                                // Add missing default role if not hidden
+                                this.settings.roles.push(defaultRole);
+                        }
 		}
 
 		// Sort roles by order

--- a/src/modals/role-edit-modal.ts
+++ b/src/modals/role-edit-modal.ts
@@ -20,8 +20,9 @@ export class RoleEditModal extends Modal {
 
 		contentEl.createEl('h2', { text: 'Edit role' });
 
-		let nameInput: HTMLInputElement;
-		let iconInput: HTMLInputElement;
+                let nameInput: HTMLInputElement;
+                let iconInput: HTMLInputElement;
+                let shortcutInput: HTMLInputElement;
 
 		new Setting(contentEl)
 			.setName('Role name')
@@ -30,27 +31,37 @@ export class RoleEditModal extends Modal {
 				text.setValue(this.role.name);
 			});
 
-		new Setting(contentEl)
-			.setName('Role icon')
-			.addText(text => {
-				iconInput = text.inputEl;
-				text.setValue(this.role.icon);
-			});
+                new Setting(contentEl)
+                        .setName('Role icon')
+                        .addText(text => {
+                                iconInput = text.inputEl;
+                                text.setValue(this.role.icon);
+                        });
+
+                new Setting(contentEl)
+                        .setName('Shortcut letter')
+                        .setDesc('Single character used with \\ to insert this role')
+                        .addText(text => {
+                                shortcutInput = text.inputEl;
+                                text.setValue(this.role.shortcut || '');
+                        });
 
 		const buttonDiv = contentEl.createDiv('button-container');
 		
 		const saveBtn = buttonDiv.createEl('button', { text: 'Save', cls: 'mod-cta' });
 		saveBtn.onclick = async () => {
 			const name = nameInput.value.trim();
-			const icon = iconInput.value.trim();
+                        const icon = iconInput.value.trim();
+                        const shortcut = shortcutInput.value.trim();
 
-			if (name && icon) {
-				this.role.name = name;
-				this.role.icon = icon;
-				await this.plugin.saveSettings();
-				this.onSave();
-				this.close();
-			}
+                        if (name && icon) {
+                                this.role.name = name;
+                                this.role.icon = icon;
+                                this.role.shortcut = shortcut || undefined;
+                                await this.plugin.saveSettings();
+                                this.onSave();
+                                this.close();
+                        }
 		};
 
 		const cancelBtn = buttonDiv.createEl('button', { text: 'Cancel' });

--- a/src/modals/role-edit-modal.ts
+++ b/src/modals/role-edit-modal.ts
@@ -20,9 +20,9 @@ export class RoleEditModal extends Modal {
 
 		contentEl.createEl('h2', { text: 'Edit role' });
 
-                let nameInput: HTMLInputElement;
-                let iconInput: HTMLInputElement;
-                let shortcutInput: HTMLInputElement;
+		let nameInput: HTMLInputElement;
+		let iconInput: HTMLInputElement;
+		let shortcutInput: HTMLInputElement;
 
 		new Setting(contentEl)
 			.setName('Role name')
@@ -31,37 +31,37 @@ export class RoleEditModal extends Modal {
 				text.setValue(this.role.name);
 			});
 
-                new Setting(contentEl)
-                        .setName('Role icon')
-                        .addText(text => {
-                                iconInput = text.inputEl;
-                                text.setValue(this.role.icon);
-                        });
+		new Setting(contentEl)
+			.setName('Role icon')
+			.addText(text => {
+				iconInput = text.inputEl;
+				text.setValue(this.role.icon);
+			});
 
-                new Setting(contentEl)
-                        .setName('Shortcut letter')
-                        .setDesc('Single character used with \\ to insert this role')
-                        .addText(text => {
-                                shortcutInput = text.inputEl;
-                                text.setValue(this.role.shortcut || '');
-                        });
+		new Setting(contentEl)
+			.setName('Shortcut letter')
+			.setDesc('Single character used with \\ to insert this role')
+			.addText(text => {
+				shortcutInput = text.inputEl;
+				text.setValue(this.role.shortcut || '');
+			});
 
 		const buttonDiv = contentEl.createDiv('button-container');
-		
+
 		const saveBtn = buttonDiv.createEl('button', { text: 'Save', cls: 'mod-cta' });
 		saveBtn.onclick = async () => {
 			const name = nameInput.value.trim();
-                        const icon = iconInput.value.trim();
-                        const shortcut = shortcutInput.value.trim();
+			const icon = iconInput.value.trim();
+			const shortcut = shortcutInput.value.trim();
 
-                        if (name && icon) {
-                                this.role.name = name;
-                                this.role.icon = icon;
-                                this.role.shortcut = shortcut || undefined;
-                                await this.plugin.saveSettings();
-                                this.onSave();
-                                this.close();
-                        }
+			if (name && icon) {
+				this.role.name = name;
+				this.role.icon = icon;
+				this.role.shortcut = shortcut || undefined;
+				await this.plugin.saveSettings();
+				this.onSave();
+				this.close();
+			}
 		};
 
 		const cancelBtn = buttonDiv.createEl('button', { text: 'Cancel' });

--- a/src/settings/task-assignment-settings-tab.ts
+++ b/src/settings/task-assignment-settings-tab.ts
@@ -161,8 +161,9 @@ export class TaskAssignmentSettingTab extends PluginSettingTab {
 
 		// Add new role
 		containerEl.createEl('h4', { text: 'Add new role' });
-		let nameInput: HTMLInputElement;
-		let iconInput: HTMLInputElement;
+                let nameInput: HTMLInputElement;
+                let iconInput: HTMLInputElement;
+                let shortcutInput: HTMLInputElement;
 
 		new Setting(containerEl)
 			.setName('Role name')
@@ -171,12 +172,20 @@ export class TaskAssignmentSettingTab extends PluginSettingTab {
 				text.setPlaceholder('Enter role name');
 			});
 
-		new Setting(containerEl)
-			.setName('Role icon')
-			.addText(text => {
-				iconInput = text.inputEl;
-				text.setPlaceholder('🎯');
-			});
+                new Setting(containerEl)
+                        .setName('Role icon')
+                        .addText(text => {
+                                iconInput = text.inputEl;
+                                text.setPlaceholder('🎯');
+                        });
+
+                new Setting(containerEl)
+                        .setName('Shortcut letter')
+                        .setDesc('Single character used with \\ to insert this role')
+                        .addText(text => {
+                                shortcutInput = text.inputEl;
+                                text.setPlaceholder('d');
+                        });
 
 		new Setting(containerEl)
 			.addButton(button => button
@@ -184,23 +193,26 @@ export class TaskAssignmentSettingTab extends PluginSettingTab {
 				.setCta()
 				.onClick(async () => {
 					const name = nameInput.value.trim();
-					const icon = iconInput.value.trim();
+                                        const icon = iconInput.value.trim();
+                                        const shortcut = shortcutInput.value.trim();
 
 					if (name && icon) {
-						const newRole: Role = {
-							id: name.toLowerCase().replace(/\s+/g, '-'),
-							name,
-							icon,
-							isDefault: false,
-							order: this.plugin.settings.roles.length + 1
-						};
+                                                const newRole: Role = {
+                                                        id: name.toLowerCase().replace(/\s+/g, '-'),
+                                                        name,
+                                                        icon,
+                                                        shortcut: shortcut || undefined,
+                                                        isDefault: false,
+                                                        order: this.plugin.settings.roles.length + 1
+                                                };
 
 						this.plugin.settings.roles.push(newRole);
 						await this.plugin.saveSettings();
 
 						nameInput.value = '';
-						iconInput.value = '';
-						this.display();
+                                                iconInput.value = '';
+                                                shortcutInput.value = '';
+                                                this.display();
 					}
 				}));
 

--- a/src/settings/task-assignment-settings-tab.ts
+++ b/src/settings/task-assignment-settings-tab.ts
@@ -161,9 +161,9 @@ export class TaskAssignmentSettingTab extends PluginSettingTab {
 
 		// Add new role
 		containerEl.createEl('h4', { text: 'Add new role' });
-                let nameInput: HTMLInputElement;
-                let iconInput: HTMLInputElement;
-                let shortcutInput: HTMLInputElement;
+		let nameInput: HTMLInputElement;
+		let iconInput: HTMLInputElement;
+		let shortcutInput: HTMLInputElement;
 
 		new Setting(containerEl)
 			.setName('Role name')
@@ -172,20 +172,20 @@ export class TaskAssignmentSettingTab extends PluginSettingTab {
 				text.setPlaceholder('Enter role name');
 			});
 
-                new Setting(containerEl)
-                        .setName('Role icon')
-                        .addText(text => {
-                                iconInput = text.inputEl;
-                                text.setPlaceholder('🎯');
-                        });
+		new Setting(containerEl)
+			.setName('Role icon')
+			.addText(text => {
+				iconInput = text.inputEl;
+				text.setPlaceholder('🎯');
+			});
 
-                new Setting(containerEl)
-                        .setName('Shortcut letter')
-                        .setDesc('Single character used with \\ to insert this role')
-                        .addText(text => {
-                                shortcutInput = text.inputEl;
-                                text.setPlaceholder('d');
-                        });
+		new Setting(containerEl)
+			.setName('Shortcut letter')
+			.setDesc('Single character used with \\ to insert this role')
+			.addText(text => {
+				shortcutInput = text.inputEl;
+				text.setPlaceholder('d');
+			});
 
 		new Setting(containerEl)
 			.addButton(button => button
@@ -193,26 +193,26 @@ export class TaskAssignmentSettingTab extends PluginSettingTab {
 				.setCta()
 				.onClick(async () => {
 					const name = nameInput.value.trim();
-                                        const icon = iconInput.value.trim();
-                                        const shortcut = shortcutInput.value.trim();
+					const icon = iconInput.value.trim();
+					const shortcut = shortcutInput.value.trim();
 
 					if (name && icon) {
-                                                const newRole: Role = {
-                                                        id: name.toLowerCase().replace(/\s+/g, '-'),
-                                                        name,
-                                                        icon,
-                                                        shortcut: shortcut || undefined,
-                                                        isDefault: false,
-                                                        order: this.plugin.settings.roles.length + 1
-                                                };
+						const newRole: Role = {
+							id: name.toLowerCase().replace(/\s+/g, '-'),
+							name,
+							icon,
+							shortcut: shortcut || undefined,
+							isDefault: false,
+							order: this.plugin.settings.roles.length + 1
+						};
 
 						this.plugin.settings.roles.push(newRole);
 						await this.plugin.saveSettings();
 
 						nameInput.value = '';
-                                                iconInput.value = '';
-                                                shortcutInput.value = '';
-                                                this.display();
+						iconInput.value = '';
+						shortcutInput.value = '';
+						this.display();
 					}
 				}));
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,11 +13,13 @@ export interface TaskAssignmentSettings {
 }
 
 export interface Role {
-	id: string;
-	name: string;
-	icon: string;
-	isDefault: boolean;
-	order: number;
+        id: string;
+        name: string;
+        icon: string;
+        /** Single letter shortcut used for quick assignment */
+        shortcut?: string;
+        isDefault: boolean;
+        order: number;
 }
 
 export interface Assignment {
@@ -131,10 +133,10 @@ export interface ViewColumn {
 }
 
 export const DEFAULT_ROLES: Role[] = [
-	{ id: 'drivers', name: 'Drivers', icon: '🚗', isDefault: true, order: 1 },
-	{ id: 'approvers', name: 'Approvers', icon: '👍', isDefault: true, order: 2 },
-	{ id: 'contributors', name: 'Contributors', icon: '👥', isDefault: true, order: 3 },
-	{ id: 'informed', name: 'Informed', icon: '📢', isDefault: true, order: 4 }
+        { id: 'drivers', name: 'Drivers', icon: '🚗', shortcut: 'd', isDefault: true, order: 1 },
+        { id: 'approvers', name: 'Approvers', icon: '👍', shortcut: 'a', isDefault: true, order: 2 },
+        { id: 'contributors', name: 'Contributors', icon: '👥', shortcut: 'c', isDefault: true, order: 3 },
+        { id: 'informed', name: 'Informed', icon: '📢', shortcut: 'i', isDefault: true, order: 4 }
 ];
 
 export const DEFAULT_SETTINGS: TaskAssignmentSettings = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,13 +13,13 @@ export interface TaskAssignmentSettings {
 }
 
 export interface Role {
-        id: string;
-        name: string;
-        icon: string;
-        /** Single letter shortcut used for quick assignment */
-        shortcut?: string;
-        isDefault: boolean;
-        order: number;
+	id: string;
+	name: string;
+	icon: string;
+	/** Single letter shortcut used for quick assignment */
+	shortcut?: string;
+	isDefault: boolean;
+	order: number;
 }
 
 export interface Assignment {
@@ -133,10 +133,10 @@ export interface ViewColumn {
 }
 
 export const DEFAULT_ROLES: Role[] = [
-        { id: 'drivers', name: 'Drivers', icon: '🚗', shortcut: 'd', isDefault: true, order: 1 },
-        { id: 'approvers', name: 'Approvers', icon: '👍', shortcut: 'a', isDefault: true, order: 2 },
-        { id: 'contributors', name: 'Contributors', icon: '👥', shortcut: 'c', isDefault: true, order: 3 },
-        { id: 'informed', name: 'Informed', icon: '📢', shortcut: 'i', isDefault: true, order: 4 }
+	{ id: 'drivers', name: 'Drivers', icon: '🚗', shortcut: 'd', isDefault: true, order: 1 },
+	{ id: 'approvers', name: 'Approvers', icon: '👍', shortcut: 'a', isDefault: true, order: 2 },
+	{ id: 'contributors', name: 'Contributors', icon: '👥', shortcut: 'c', isDefault: true, order: 3 },
+	{ id: 'informed', name: 'Informed', icon: '📢', shortcut: 'i', isDefault: true, order: 4 }
 ];
 
 export const DEFAULT_SETTINGS: TaskAssignmentSettings = {


### PR DESCRIPTION
## Summary
- add optional `shortcut` to `Role`
- allow customizing shortcut letters in Role settings
- integrate with Tasks plug‑in autosuggest
- provide `\` role shortcut autosuggest
- document backslash shortcuts

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_68704f2d2bbc8329bd6e193b45267c20