### PR TITLE
Fix suggestions not showing in assignee selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"lint:md:fix": "markdownlint \"**/*.md\" --ignore node_modules --fix",
 		"lint:fix": "npm run lint:ts:fix && npm run lint:md:fix",
 		"preversion": "npm run lint",
-    "pretest": "tsc src/services/task-assignment.service.ts src/modals/assignee-selector-modal.ts src/types/index.ts --skipLibCheck --esModuleInterop --module ES2020 --target ES2020 --moduleResolution node --typeRoots tests --outDir dist-test",
+		"pretest": "tsc src/services/task-assignment.service.ts src/modals/assignee-selector-modal.ts src/types/index.ts --skipLibCheck --esModuleInterop --module ES2020 --target ES2020 --moduleResolution node --typeRoots tests --outDir dist-test",
 		"test": "NODE_PATH=tests node --test tests/task-assignment.service.test.js"
 	},
 	"keywords": [],

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"lint:md:fix": "markdownlint \"**/*.md\" --ignore node_modules --fix",
 		"lint:fix": "npm run lint:ts:fix && npm run lint:md:fix",
 		"preversion": "npm run lint",
-		"pretest": "tsc src/services/task-assignment.service.ts src/types/index.ts --skipLibCheck --esModuleInterop --module ES2020 --target ES2020 --moduleResolution node --typeRoots tests --outDir dist-test",
+    "pretest": "tsc src/services/task-assignment.service.ts src/modals/assignee-selector-modal.ts src/types/index.ts --skipLibCheck --esModuleInterop --module ES2020 --target ES2020 --moduleResolution node --typeRoots tests --outDir dist-test",
 		"test": "NODE_PATH=tests node --test tests/task-assignment.service.test.js"
 	},
 	"keywords": [],

--- a/src/modals/assignee-selector-modal.ts
+++ b/src/modals/assignee-selector-modal.ts
@@ -35,13 +35,13 @@ export class AssigneeSelectorModal extends FuzzySuggestModal<string> {
 		}
 	}
 
-        async onOpen() {
-                super.onOpen();
-                this.contacts = await this.plugin.taskAssignmentService.getContactsAndCompanies(this.plugin.settings.contactSymbol);
-                this.companies = await this.plugin.taskAssignmentService.getContactsAndCompanies(this.plugin.settings.companySymbol);
-                // Refresh suggestions after async data is loaded
-                this.inputEl.dispatchEvent(new Event('input'));
-        }
+	async onOpen() {
+		super.onOpen();
+		this.contacts = await this.plugin.taskAssignmentService.getContactsAndCompanies(this.plugin.settings.contactSymbol);
+		this.companies = await this.plugin.taskAssignmentService.getContactsAndCompanies(this.plugin.settings.companySymbol);
+		// Refresh suggestions after async data is loaded
+		this.inputEl.dispatchEvent(new Event('input'));
+	}
 
 	getItems(): string[] {
 		this.currentQuery = this.inputEl.value;

--- a/src/modals/assignee-selector-modal.ts
+++ b/src/modals/assignee-selector-modal.ts
@@ -35,11 +35,13 @@ export class AssigneeSelectorModal extends FuzzySuggestModal<string> {
 		}
 	}
 
-	async onOpen() {
-		super.onOpen();
-		this.contacts = await this.plugin.taskAssignmentService.getContactsAndCompanies(this.plugin.settings.contactSymbol);
-		this.companies = await this.plugin.taskAssignmentService.getContactsAndCompanies(this.plugin.settings.companySymbol);
-	}
+        async onOpen() {
+                super.onOpen();
+                this.contacts = await this.plugin.taskAssignmentService.getContactsAndCompanies(this.plugin.settings.contactSymbol);
+                this.companies = await this.plugin.taskAssignmentService.getContactsAndCompanies(this.plugin.settings.companySymbol);
+                // Refresh suggestions after async data is loaded
+                this.inputEl.dispatchEvent(new Event('input'));
+        }
 
 	getItems(): string[] {
 		this.currentQuery = this.inputEl.value;

--- a/tests/assignee-selector-modal.test.js
+++ b/tests/assignee-selector-modal.test.js
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { App, FuzzySuggestModal } from './obsidian/index.js';
+import { AssigneeSelectorModal } from '../dist-test/modals/assignee-selector-modal.js';
+import { DEFAULT_SETTINGS } from '../dist-test/types/index.js';
+
+function createPlugin() {
+  const app = new App();
+  const service = {
+    getContactsAndCompanies: async (symbol) => {
+      return symbol === DEFAULT_SETTINGS.contactSymbol ? ['John'] : ['Acme'];
+    }
+  };
+  return { app, settings: DEFAULT_SETTINGS, taskAssignmentService: service };
+}
+
+test('onOpen refreshes suggestions by dispatching input event', async () => {
+  const plugin = createPlugin();
+  const modal = new AssigneeSelectorModal(plugin.app, plugin, () => {});
+  await modal.onOpen();
+  assert.ok(modal.inputEl.dispatched.includes('input'));
+});

--- a/tests/assignee-selector-modal.test.js
+++ b/tests/assignee-selector-modal.test.js
@@ -16,7 +16,7 @@ function createPlugin() {
 
 test('onOpen refreshes suggestions by dispatching input event', async () => {
   const plugin = createPlugin();
-  const modal = new AssigneeSelectorModal(plugin.app, plugin, () => {});
+  const modal = new AssigneeSelectorModal(plugin.app, plugin, () => { });
   await modal.onOpen();
   assert.ok(modal.inputEl.dispatched.includes('input'));
 });

--- a/tests/obsidian.d.ts
+++ b/tests/obsidian.d.ts
@@ -4,4 +4,13 @@ declare module 'obsidian' {
   export class TFolder extends TAbstractFile { children: TAbstractFile[]; }
   export class App { vault: any; workspace: any; }
   export class Notice { constructor(message: string, timeout?: number); }
+  export class FuzzySuggestModal<T> {
+    app: App;
+    inputEl: { value: string; dispatchEvent(e: Event): void };
+    constructor(app: App);
+    setPlaceholder(text: string): void;
+    onOpen(): void;
+    onNoSuggestion(): void;
+    close(): void;
+  }
 }

--- a/tests/obsidian/index.js
+++ b/tests/obsidian/index.js
@@ -2,3 +2,17 @@ export class TFile { constructor() { this.extension=''; this.basename=''; this.s
 export class TFolder { constructor(){this.children=[];}}
 export class Notice { constructor(msg){ this.msg=msg; }}
 export class App { constructor(){ this.vault={getAbstractFileByPath(){}, getMarkdownFiles(){return []}, adapter:{exists(){return false}, write(){}, read(){}, create(){}, createFolder(){},}}; this.workspace={}; }}
+export class FuzzySuggestModal {
+  constructor(app) {
+    this.app = app;
+    this.inputEl = {
+      value: '',
+      dispatched: [],
+      dispatchEvent: (e) => { this.inputEl.dispatched.push(e.type); }
+    };
+  }
+  setPlaceholder() {}
+  onOpen() {}
+  onNoSuggestion() {}
+  close() {}
+}

--- a/tests/obsidian/index.js
+++ b/tests/obsidian/index.js
@@ -1,7 +1,7 @@
-export class TFile { constructor() { this.extension=''; this.basename=''; this.stat={ctime:0,mtime:0}; } }
-export class TFolder { constructor(){this.children=[];}}
-export class Notice { constructor(msg){ this.msg=msg; }}
-export class App { constructor(){ this.vault={getAbstractFileByPath(){}, getMarkdownFiles(){return []}, adapter:{exists(){return false}, write(){}, read(){}, create(){}, createFolder(){},}}; this.workspace={}; }}
+export class TFile { constructor() { this.extension = ''; this.basename = ''; this.stat = { ctime: 0, mtime: 0 }; } }
+export class TFolder { constructor() { this.children = []; } }
+export class Notice { constructor(msg) { this.msg = msg; } }
+export class App { constructor() { this.vault = { getAbstractFileByPath() { }, getMarkdownFiles() { return [] }, adapter: { exists() { return false }, write() { }, read() { }, create() { }, createFolder() { }, } }; this.workspace = {}; } }
 export class FuzzySuggestModal {
   constructor(app) {
     this.app = app;
@@ -11,8 +11,8 @@ export class FuzzySuggestModal {
       dispatchEvent: (e) => { this.inputEl.dispatched.push(e.type); }
     };
   }
-  setPlaceholder() {}
-  onOpen() {}
-  onNoSuggestion() {}
-  close() {}
+  setPlaceholder() { }
+  onOpen() { }
+  onNoSuggestion() { }
+  close() { }
 }


### PR DESCRIPTION
## Summary
- compile `AssigneeSelectorModal` for tests and create a unit test
- stub `FuzzySuggestModal` for node tests
- refresh suggestions when contacts/companies load

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68713447b63c83299a71dddd65495cc4