### PR TITLE
fix: correct cursor positioning for backslash trigger with existing role assignees

### DIFF
--- a/src/editor/shortcuts-trigger.ts
+++ b/src/editor/shortcuts-trigger.ts
@@ -120,16 +120,20 @@ export function shortcutsTrigger(app: App, settings: TaskRolesPluginSettings) {
 					);
 					if (cursorInfo) {
 						// Remove the backslash trigger
+						const backslashPos = cursor.ch - 1;
 						const startPos = {
 							line: cursor.line,
-							ch: cursor.ch - 1,
+							ch: backslashPos,
 						};
 						editor.replaceRange("", startPos, cursor);
 
 						// Position cursor at the role
+						// Only adjust for removed backslash if it was before the role position
 						let cursorPos = {
 							line: cursor.line,
-							ch: cursorInfo.position - 1, // Adjust for removed backslash
+							ch: backslashPos < cursorInfo.position 
+								? cursorInfo.position - 1 
+								: cursorInfo.position,
 						};
 
 						// If there are existing assignees, add separator and space

--- a/tests/cursor-positioning.test.ts
+++ b/tests/cursor-positioning.test.ts
@@ -45,6 +45,24 @@ describe('TaskUtils.findRoleCursorPosition', () => {
         expect(result).toBeTruthy();
         expect(result?.needsSeparator).toBe(false);
     });
+
+    it('should handle wikilinks with multiple assignees correctly', () => {
+        const line = '- [ ] T [🚗:: [[Task Roles Demo/People/Me|@Me]], [[Task Roles Demo/People/Tommy|@Tommy]]] ➕ 2025-07-22';
+        const result = TaskUtils.findRoleCursorPosition(line, testRole);
+
+        expect(result).toBeTruthy();
+        expect(result?.position).toBe(88); // Before the closing bracket of the role assignment
+        expect(result?.needsSeparator).toBe(true);
+    });
+
+    it('should handle wikilinks with nested brackets in path', () => {
+        const line = '- [ ] T [🚗:: [[Complex/Path [with brackets]/Person|@Person]]] test';
+        const result = TaskUtils.findRoleCursorPosition(line, testRole);
+
+        expect(result).toBeTruthy();
+        expect(result?.position).toBe(61); // Before the closing bracket of the role assignment
+        expect(result?.needsSeparator).toBe(true);
+    });
 });
 
 describe('Shortcut uniqueness validation', () => {


### PR DESCRIPTION
## Summary
- Fixed cursor positioning bug when using backslash shortcuts (\d, \a, \c, \i) on tasks that already have assignees for that role
- Cursor now correctly positions before the closing bracket instead of after it
- Added comprehensive tests for wikilink scenarios with nested brackets

## Test plan
- [x] Verified fix works for wikilinks with multiple assignees
- [x] Tested scenarios with nested brackets in wikilink paths
- [x] Ensured backward compatibility with existing behavior
- [x] All linting and build tests pass

The cursor is now positioned correctly to allow adding new assignees to existing roles.